### PR TITLE
incorrect handling of script arguments with spaces

### DIFF
--- a/nimcr.nim
+++ b/nimcr.nim
@@ -66,10 +66,9 @@ if not exeName.existsFile or filename.fileNewer exeName:
 if buildStatus == 0:
   let p = startProcess(exeName,  args=args[filenamePos+1 .. ^1], 
                        options={poStdErrToStdOut, poParentStreams, poUsePath})
-  while p.running():
-    sleep(1)
+  let res = p.waitForExit()
   p.close()
-  quit p.peekExitCode()
+  quit res
 else:
   stderr.write "(nimcr) Error on build running command: " & command
   stderr.write output

--- a/nimcr.nim
+++ b/nimcr.nim
@@ -64,7 +64,12 @@ if not exeName.existsFile or filename.fileNewer exeName:
 
 # Run the target, or show an error
 if buildStatus == 0:
-  quit execShellCmd(exeName & " " & args[filenamePos + 1 .. ^1].join(" "))
+  let p = startProcess(exeName,  args=args[filenamePos+1 .. ^1], 
+                       options={poStdErrToStdOut, poParentStreams, poUsePath})
+  while p.running():
+    sleep(1)
+  p.close()
+  quit p.peekExitCode()
 else:
   stderr.write "(nimcr) Error on build running command: " & command
   stderr.write output


### PR DESCRIPTION
Running `examples/testfile.nim klm "abc def"` will result in the last line of output being `@["klm", "abc", "def"]` which is incorrect. As 
it should be `@["klm", "abc def"]`.

The cause for this is the incorrect stringification, without quotes, for `execShellCmd`.  Using `startProcess` you can hand in the already split arguments, and not have the overhead of another shell invocation.

Fixes issue #3 