### PR TITLE
Move arguments to nim compiler to second line of the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,46 @@
 # Running Nim code with Shebangs
-Shebangs are a tiny comment at the beginning of a file that tells the operating system what program can be used to run the contents of that file. It is typically seen in bash scripts starting with #!/bin/bash or in Python scripts as #!/usr/bin/env python. Nim however is not an interpreted language, this means that having a program that "runs" Nim files would actually mean compile and run. This was outlined in issue [#66](https://github.com/nim-lang/Nim/issues/66) for Nim but was closed after Araq showed how it could be achieved with flags to the compiler. However this solution is a bit lacking. Nim, being a compiled langage, offer a speed benefit over many other languages. So writing scripts in Nim makes sense if you want to have a lot of scripts running on your machine. But compiling the script every time you want to run it makes no sense at all as it completely negates the speed benefit.
+Shebangs are a tiny comment at the beginning of a file that tells the operating system what program can be used to run the contents of that file. It is typically seen in bash scripts starting with `#!/bin/bash` or in Python scripts as `#!/usr/bin/env python`. Nim however is not an interpreted language, this means that having a program that "runs" Nim files would actually mean compile and run. This was outlined in issue [#66](https://github.com/nim-lang/Nim/issues/66) for Nim but was closed after Araq showed how it could be achieved with flags to the compiler. However this solution is a bit lacking. Nim, being a compiled language, offers a speed benefit over many other languages. So writing scripts in Nim makes sense if you want to have a lot of scripts running on your machine. But compiling the script every time you want to run it makes no sense at all as it completely negates the speed benefit.
 
 ## The solution
-This project aims to be a tiny little program to solve the problem of using Nim for scripting. It takes the file passed to it through the shebang and establishes a nimcache directory in temporary storage, then it compiles the script to a hidden file next to the script itself. On subsequent runs it checks if the script file is younger than the executable (ie. been edited after the last compilation) in which case it will compile it again, reusing the same nimcache directory if it exists. This means that the very first run of a script will do the entire compilation process, subsequent runs without changes will only run the executable, and runs where the source is newer than the executable will do the compilation process but use the old nimcache. The sum of this is a great speed-benefit without losing any of the flexibility often associated with scripts in general. Simply mark the script as executable and run it!
+This project aims to be a tiny little program to solve the problem of using Nim for scripting. It takes the file passed to it through the shebang and establishes a nimcache directory in temporary storage, then it compiles the script to a hidden file next to the script itself. On subsequent runs it checks if the script file is newer than the executable (ie. been edited after the last compilation) in which case it will compile it again, reusing the same nimcache directory if it exists. This means that the very first run of a script will do the entire compilation process, subsequent runs without changes will only run the executable, and runs where the source is newer than the executable will do the compilation process but use the old nimcache. The sum of this is a great speed-benefit without losing any of the flexibility often associated with scripts in general. Simply mark the script as executable and run it!
 
 ## A note on output
 To make the output of a script as uniform as possible in order for it to easily pipe to other processes this program will hide the compilation output. As long as the Nim compiler completes without errors only the output of the script will be written to the terminal. In the case of a compiler failure the entire Nim compilation output along with the executed command will be written to stderr. This program will then exit with the error code of the compiler.
 
-## Passing options
-Originally nimcr didn't support any options other than compile target (C, C++, JS, etc.) but support for this has now been added. When using options you are required to specify the compile target first, followed by any options you might want. So an example shebang for this would look like this `#!nimcr c --deadCodeElim:on`, note the initial `c` specifying the compile target. If you want your script to be able to take arguments of it's own, this line has to end with `--` so the previous shebang would be `#!nimcr c --deadCodeElim:on --`. Nimcr will then attempt to run your script with any arguments passed over the command line, while any arguments specified before the `--` in the shebang will be sent to the Nim compiler. Omitting the `--` as in previous versions will work as before, but you won't be able to pass arguments to the script. Note that some implementations of shebangs don't allow more than a single argument. This means that nimcr also supports passing in all arguments as a string. So the above shebang could also be written as `#!nimcr "c --deadCodeElim:on --"`.
+## How to compile/run your script using nimcr
+Make the first line in your nim script read as follows: `#!/usr/bin/env nimcr` and optionally make the script executable.
 
+## Passing options
+**WARNING** since version 1.0.0 the syntax for passing command line options has changed in an non-backwards compatible manner. This was necessary in order to support passing options to the nim compiler as well as the actual script in a way that works across different platforms supporting shebangs.
+
+Command line options can be specified for the nim compiler and for the actual script.
+
+### Options for the script
+Options for the script are passed on the command line as you would with any other program, like so:
+
+``` bash
+# Example 1: do not pass command line switches nor arguments for the script
+$ ./script-using-nimcr
+# Example 2: path both command line switches and arguments
+$ ./script-using-nimcr -option1 -option2 positional_arg1 positional_arg2
+```
+
+The script will be able to access command line switches and arguments as any other nim program.
+
+### Options for the nim compiler
+Options for the nim compiler can be specified by adding a specially formatted comment as second line of the script starting with `#nimcr-args` followed by a space then followed by command line switches and arguments to the nim compiler.
+
+``` bash
+#!/usr/bin/env nimcr
+#nimcr-args c --opt:size
+
+... rest of the script
+```
+
+If `#nimcr-args` is not present as second line of the script it defaults to `c -d:release`.
+
+### Options automatically appended by nimcr
 In order for nimcr to work and be convenient, some options are added to the execution and will throw an error or give unwanted behaviour when combined with conflicting options. These options are:
 ```
---colors:on --nimcache:<cache directory> -d:release --out:<hidden file>
+--colors:on --nimcache:<cache directory> --out:<hidden file>
 ```

--- a/examples/testfile.nim
+++ b/examples/testfile.nim
@@ -1,4 +1,4 @@
-#!nimcr "c --deadCodeElim:on --"
+#!/usr/bin/env nimcr
 echo "Hello World!"
 
 import os

--- a/nimcr.nim
+++ b/nimcr.nim
@@ -31,7 +31,7 @@ var
   command = ""
 
 if not exeName.existsFile or filename.fileNewer exeName:
-  var nimArgs: string = "c"
+  var nimArgs: string = "c -d:release"
   # Get extra arguments for nim compiler from the second line (it must start with #nimcr-args [args] )
   block:
     let scriptfile = open(filename)
@@ -45,7 +45,7 @@ if not exeName.existsFile or filename.fileNewer exeName:
   exeName.removeFile
   command = "nim " & nimArgs & " --colors:on --nimcache:" &
     getTempDir()/("nimcache-" & filename.hash.toHex) &
-    " -d:release --out:\"" & exeName & "\" " & filename
+    " --out:\"" & exeName & "\" " & filename
 
   (output, buildStatus) = execCmdEx(command)
   # Windows file hiding (hopefully, not tested)

--- a/nimcr.nim
+++ b/nimcr.nim
@@ -5,19 +5,14 @@ import hashes, strutils
 let args =  commandLineParams()
 
 if args.len == 0:
-  stderr.write "Usage: nimcr [compile target, default 'c' [options] --] filename [arguments to program]\n"
+  stderr.write "Usage on the command line: nimcr filename [arguments to program]\n"
+  stderr.write "Usage in a script:\n"
+  stderr.write "\t1- add `#!/usr/bin/env nimcr` to your script as first line\n"
+  stderr.write "\t2- (optional) add `#nimcr-args [arguments for nim compiler]` to your script as second line\n"
   quit -1
 
-var filenamePos = args.high
-for i in 0..args.high:
-  # Linux passes all args in as a single string, BSD  splits it into multiple arguments
-  let arguments = if args[i][0] == '"' and args[i][^1] == '"': args[i][1..^2] else: args[i]
-  if arguments == "--" or arguments.strip().endsWith(" --"):
-    filenamePos = i + 1
-    break
-
-let
-  filename = args[filenamePos].expandFilename
+var filenamePos = args.low
+let filename = args[filenamePos].expandFilename
 
 # Split the file path and make a new one which is a hidden file on Linux, Windows file hiding comes later
 let
@@ -36,24 +31,19 @@ var
   command = ""
 
 if not exeName.existsFile or filename.fileNewer exeName:
-  # Get any extra arguments from the command and compile
-  var
-    splittingArg = if filenamePos > 0:
-      if args[filenamePos - 1][0] == '"' and args[filenamePos - 1][^1] == '"':
-        args[filenamePos - 1][1..^2].strip()
-      else:
-        args[filenamePos - 1].strip()
-    else: ""
-  splittingArg.removeSuffix(" --")
-  if splittingArg == "--": splittingArg = ""
-  let extraArgs =
-    if filenamePos > 0:
-      args[0..filenamePos-2].join(" ") & " " & splittingArg
-    else:
-      "c"
+  var nimArgs: string = "c"
+  # Get extra arguments for nim compiler from the second line (it must start with #nimcr-args [args] )
+  block:
+    let scriptfile = open(filename)
+    defer: scriptfile.close()
+    discard scriptfile.readLine()
+    var secondLine = scriptfile.readLine()
+    if secondLine.startsWith("#nimcr-args "):
+      secondLine.removePrefix("#nimcr-args ")
+      nimArgs = secondLine
 
   exeName.removeFile
-  command = "nim " & extraArgs & " --colors:on --nimcache:" &
+  command = "nim " & nimArgs & " --colors:on --nimcache:" &
     getTempDir()/("nimcache-" & filename.hash.toHex) &
     " -d:release --out:\"" & exeName & "\" " & filename
 
@@ -64,7 +54,7 @@ if not exeName.existsFile or filename.fileNewer exeName:
 
 # Run the target, or show an error
 if buildStatus == 0:
-  let p = startProcess(exeName,  args=args[filenamePos+1 .. ^1], 
+  let p = startProcess(exeName,  args=args[args.low+1 .. ^1],
                        options={poStdErrToStdOut, poParentStreams, poUsePath})
   let res = p.waitForExit()
   p.close()

--- a/nimcr.nimble
+++ b/nimcr.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.0"
+version       = "0.3.0"
 author        = "Peter Munch-Ellingsen"
 description   = "Simple program that allows you to use the shebang #!nimcr in your Nim files. It will automatically compile the file to a hidden executable in the same directory as the nim file as long as the file doesn\'t already exist and is younger than (ie. created after the last modification of) the script file. If it is younger it will simply run the executable saving you from compiling the script each time it is run. The output of the compiler is also ignored if the compilation is succesfull and only the output of the program is used. If the compilation fails the output will be written to stderr and the return code will match that of the compiler."
 license       = "MIT"


### PR DESCRIPTION

Rely on minimal `#!` and `env` features and move all arguments to nim compiler to the second line of the script.

Backwards compatible argument passing could be implement by parsing the shebang and subtracting arguments listed there from arguments received at runtime. IMHO it would be an unnecessary complication.

TODO:
* [x] documentation changes
